### PR TITLE
Totally trivial change to remove the Syphon Server name.

### DIFF
--- a/uirendersyphon.mm
+++ b/uirendersyphon.mm
@@ -16,13 +16,9 @@ UiRenderSyphon::~UiRenderSyphon() {
 
 void UiRenderSyphon::openPort() {
     NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-
-    NSString *title = @"IanniX";
-
+    
     if(!mSyphon)
-        mSyphon = [[SyphonServer alloc] initWithName:title context:CGLGetCurrentContext() options:nil];
-    else
-        [(SyphonServer *)mSyphon setName:title];
+        mSyphon = [[SyphonServer alloc] initWithName:nil context:CGLGetCurrentContext() options:nil];
 
     [pool drain];
 }


### PR DESCRIPTION
This is purely cosmetic - it means other apps show a server called "IanniX" instead of "IanniX - IanniX". A name is used to differentiate between multiple servers from the same app, but IanniX has only one server.
