### PR TITLE
Qreal on arm

### DIFF
--- a/abstractionsgl.cpp
+++ b/abstractionsgl.cpp
@@ -503,8 +503,8 @@ void OpenGlDrawing::drawRect(OpenGlTexture *texture, qreal alpha, qreal selected
 }
 void OpenGlDrawing::drawRect(const QRectF &rect, const OpenGlColors &colors, OpenGlTexture *texture, qreal alpha, qreal selected, qreal croppingMode, bool ninePatch, QRectF partialTextureRect) {
     QRectF textureRect, targetRect = rect;
-    alpha    = qBound(0., alpha,    1.);
-    selected = qBound(0., selected, 1.);
+    alpha    = qBound(qreal(0.), alpha,    qreal(1.));
+    selected = qBound(qreal(0.), selected, qreal(1.));
 
     //Cropping
     if(!colors.isColorTransparent()) {
@@ -716,7 +716,7 @@ qreal OpenGlDrawing::drawText(QPainter *painter, const QColor &color, const Open
                 //painter->drawStaticText(QPointF(0, 0), staticText);
                 //qDebug("%s\tH:%f\tC:%f\tSH:%f\tPOS:%f", qPrintable(text), rect.height(), rect.center().y(), staticText.size().height(), rect.center().y() - staticText.size().height()/2);
                 if((font.alignementFlags() & Qt::AlignVCenter) == Qt::AlignVCenter)
-                    pos.setY(qMax(0., rect.center().y() - fontHeight/2));
+                    pos.setY(qMax(qreal(0.), rect.center().y() - fontHeight/2));
                 else if((font.alignementFlags() & Qt::AlignBottom) == Qt::AlignBottom)
                     pos.setY(rect.bottom() - fontHeight);
 

--- a/geometry/nxeasing.h
+++ b/geometry/nxeasing.h
@@ -38,7 +38,7 @@ public:
 public:
     inline void setType(quint16 type)           { easing.setType((QEasingCurve::Type)type); }
     inline quint16 getType() const              { return easing.type(); }
-    inline qreal getValue(qreal progress) const { return qBound(0., easing.valueForProgress(progress), 1.); }
+    inline qreal getValue(qreal progress) const { return qBound(qreal(0.), easing.valueForProgress(progress), qreal(1.)); }
 };
 
 #endif // NXEASING_H

--- a/geometry/qmuparser/muParserDef.h
+++ b/geometry/qmuparser/muParserDef.h
@@ -49,7 +49,9 @@
   This datatype must be a built in value type. You can not use custom classes.
   It should be working with all types except "int"!
 */
-#define MUP_BASETYPE double
+#ifndef MUP_BASETYPE
+# define MUP_BASETYPE double
+#endif /* MUP_BASETYPE */
 
 /** \brief Activate this option in order to compile with OpenMP support.
 

--- a/objects/nxcursor.cpp
+++ b/objects/nxcursor.cpp
@@ -290,10 +290,10 @@ void NxCursor::paint() {
         else if(Render::colors->contains(colorInactive))                                                                color = Render::colors->value(colorInactive);
         else                                                                                                            color = Qt::gray;
     }
-    color.setRgb (qBound(0., color.red()   * colorMultiplyColor.redF(),   255.),
-                  qBound(0., color.green() * colorMultiplyColor.greenF(), 255.),
-                  qBound(0., color.blue()  * colorMultiplyColor.blueF(),  255.),
-                  qBound(0., color.alpha() * colorMultiplyColor.alphaF(), 255.));
+    color.setRgb (qBound(qreal(0.), color.red()   * colorMultiplyColor.redF(),   qreal(255.)),
+                  qBound(qreal(0.), color.green() * colorMultiplyColor.greenF(), qreal(255.)),
+                  qBound(qreal(0.), color.blue()  * colorMultiplyColor.blueF(),  qreal(255.)),
+                  qBound(qreal(0.), color.alpha() * colorMultiplyColor.alphaF(), qreal(255.)));
 
     if(color.alpha() > 0) {
         //Mouse hover
@@ -408,7 +408,7 @@ void NxCursor::paint() {
                 glRotatef(cursorAngle.z(), 0, 0, 1);
                 glRotatef(cursorAngle.y(), 0, 1, 0);
                 glRotatef(cursorAngle.x(), 1, 0, 0);
-                qreal size2 = Render::objectSize / 2 * qMin(1., width);
+                qreal size2 = Render::objectSize / 2 * qMin(qreal(1.), width);
                 glBegin(GL_TRIANGLE_FAN);
                 glLineWidth(2);
                 if(hasActivity) {

--- a/objects/nxcurve.cpp
+++ b/objects/nxcurve.cpp
@@ -155,10 +155,10 @@ void NxCurve::paint() {
         else if(Render::colors->contains(colorInactive))                                                                color = Render::colors->value(colorInactive);
         else                                                                                                            color = Qt::gray;
     }
-    color.setRgb (qBound(0., color.red()   * colorMultiplyColor.redF(),   255.),
-                  qBound(0., color.green() * colorMultiplyColor.greenF(), 255.),
-                  qBound(0., color.blue()  * colorMultiplyColor.blueF(),  255.),
-                  qBound(0., color.alpha() * colorMultiplyColor.alphaF(), 255.));
+    color.setRgb (qBound(qreal(0.), color.red()   * colorMultiplyColor.redF(),   qreal(255.)),
+                  qBound(qreal(0.), color.green() * colorMultiplyColor.greenF(), qreal(255.)),
+                  qBound(qreal(0.), color.blue()  * colorMultiplyColor.blueF(),  qreal(255.)),
+                  qBound(qreal(0.), color.alpha() * colorMultiplyColor.alphaF(), qreal(255.)));
 
     if(color.alpha() > 0) {
         //Mouse hover

--- a/objects/nxtrigger.cpp
+++ b/objects/nxtrigger.cpp
@@ -61,10 +61,10 @@ void NxTrigger::paint() {
         else if(Render::colors->contains(colorInactive))                                                                color = Render::colors->value(colorInactive);
         else                                                                                                            color = Qt::gray;
     }
-    color.setRgb (qBound(0., color.red()   * colorMultiplyColor.redF(),   255.),
-                  qBound(0., color.green() * colorMultiplyColor.greenF(), 255.),
-                  qBound(0., color.blue()  * colorMultiplyColor.blueF(),  255.),
-                  qBound(0., color.alpha() * colorMultiplyColor.alphaF(), 255.));
+    color.setRgb (qBound(qreal(0.), color.red()   * colorMultiplyColor.redF(),   qreal(255.)),
+                  qBound(qreal(0.), color.green() * colorMultiplyColor.greenF(), qreal(255.)),
+                  qBound(qreal(0.), color.blue()  * colorMultiplyColor.blueF(),  qreal(255.)),
+                  qBound(qreal(0.), color.alpha() * colorMultiplyColor.alphaF(), qreal(255.)));
 
     //Size of trigger
     if(cacheSize != Render::objectSize*size) {


### PR DESCRIPTION
This PR attempts to fix the build-problems with arm-architectures, where `qreal` is *not* `double`.

The first patch homogenizes the argument types for template functions (so all values are of type `qreal`, rather than some being native `double`, and others being `qreal`).

The second patch allows to set the base-type of the *muparser* (which defaults to `double`), as this must be the same as `qreal`. This is done by making the `#define MUP_BASETYPE` optional (only if no MUP_BASETYPE has been defined beforehnd, e.g. on the cmdline).
The second patch does not enforce `MUP_BASETYPE == float` on arm architectures (or `MUP_BASETYPE == qreal`) in order to keep the patch minimal (and more likely to be applied up-upstream, if that applies).

This means, that when compiling IanniX for arm architectures, one still has to (manually) add something like `-DMUP_BASETYPE=float` to the preprocesser flags, which is good enough for me.
There *might* be a way to detect arm-builds in the qmakefile, and automatically add the CPPFLAG, but I haven't dug into this.

Closes https://github.com/buzzinglight/IanniX/issues/26