### PR TITLE
fixes from Debian packaging

### DIFF
--- a/iannix.desktop
+++ b/iannix.desktop
@@ -7,4 +7,4 @@ Terminal=false
 Type=Application
 X-MultipleArgs=false
 Categories=Audio;AudioVideoEditing;AudioVideo;Video;Qt;
-Name[en_US]=IanniX.desktop
+Name[en_US]=IanniX

--- a/objects/nxcurve.h
+++ b/objects/nxcurve.h
@@ -28,6 +28,7 @@
 #include <QScriptValue>
 #include <QVarLengthArray>
 #include <QBitmap>
+#include <QPainterPath>
 #include "geometry/qmuparser/muParser.h"
 #include "nxobject.h"
 #include "qmath.h"


### PR DESCRIPTION
in Debian,  iannix started to *fail to build from source* recently, because the Qt5 that comes with (the next release of) Debian has been updated to **Qt-5.15**, which obviously requires to include `<QPainterPath>` explicitly, if you want to use it.

this PR also fixes a minor display issue with the desktop file.

