### PR TITLE
Update iannix.desktop - wrong path for IanniX icon (Linux)

### DIFF
--- a/iannix.desktop
+++ b/iannix.desktop
@@ -2,7 +2,7 @@
 Name=IanniX
 Comment=Graphical sequencer for digital art
 Exec=IanniX
-Icon=/usr/share/pixmaps/IanniX.png
+Icon=/usr/share/pixmaps/iannix.png
 Terminal=false
 Type=Application
 X-MultipleArgs=false


### PR DESCRIPTION
iannix.desktop Icon's Path was pointing to /usr/share/pixmaps/IanniX.png instead of /usr/share/pixmaps/iannix.png (also used in IanniX.pro) 